### PR TITLE
add Zoom Workplace Enterprise calling plan

### DIFF
--- a/internal/services/phone/usercallingplans/user_calling_plans_resource.go
+++ b/internal/services/phone/usercallingplans/user_calling_plans_resource.go
@@ -103,6 +103,7 @@ var callingPlanMapping = map[int32]string{
 	70202: "MEETINGS_GB_IE_NUMBER_INCLUDED",
 	70207: "MEETINGS_JP_NUMBER_INCLUDED",
 	71000: "MEETINGS_GLOBAL_SELECT_NUMBER_INCLUDED",
+	83000: "ZOOM_WORKPLACE_ENTERPRISE", // FIXME change when finding correct value on https://developers.zoom.us/docs/api/rest/other-references/calling-plans/
 }
 
 func NewPhoneUserCallingPlansResource() resource.Resource {


### PR DESCRIPTION
We can use `Zoom Workplace Enterprise` calling plan, which is not shown on [doc](https://developers.zoom.us/docs/api/rest/other-references/calling-plans/).

```sh
> curl -s -H'Content-Type: application/json' -H "Authorization: Bearer $token" 'https://api.zoom.us/v2/phone/calling_plans' | jq .
{
  "calling_plans": [
    {
      "type": 1001,
      "name": "Global Select Metered Calling Plan",
      "subscribed": 1,
      "assigned": 0,
      "available": 1
    },
    {
      "type": 83000,
      "name": "Zoom Workplace Enterprise",
      "subscribed": 999,
      "assigned": 99,
      "available": 900
    }
  ]
}
```