### PR TITLE
Fix: Ensure unique users in phone user list response via anti-corruption layer

### DIFF
--- a/internal/services/phone/user/user_crud.go
+++ b/internal/services/phone/user/user_crud.go
@@ -88,7 +88,10 @@ func (c *crud) list(ctx context.Context, dto listQueryDto) (*listDto, error) {
 	}
 
 	return &listDto{
-		users: users,
+		// Ensure uniqueness by using user ID, as duplicate data may occasionally be retrieved.
+		users: lo.UniqBy(users, func(item listDtoUser) string {
+			return item.userID.ValueString()
+		}),
 	}, nil
 }
 


### PR DESCRIPTION
## Description

This PR addresses an issue where the phone user list API response occasionally included duplicate user entries. To prevent this, I’ve updated the anti-corruption layer to ensure that the returned user list contains only unique entries.

## Changes

Added a deduplication step in the anti-corruption layer to filter out duplicate users.
Ensured that uniqueness is determined based on user ID.
Added a unit test to verify that the deduplication logic works as expected.

## Motivation

This change was necessary because the downstream systems relying on the phone user list API were experiencing inconsistencies due to duplicated user entries. By enforcing uniqueness at the anti-corruption layer, we ensure data integrity without modifying the upstream service.

```log
╷
│ Error: Duplicate Set Element
│ 
│   with module.phone.data.zoom_phone_users.this,
│   on phone/users.tf line 1, in data "zoom_phone_users" "this":
│    1: data "zoom_phone_users" "this" {
│ 
│ This attribute contains duplicate values of:
│ tftypes.Object["calling_plans":tftypes.Set[tftypes.Object["billing_account_id":tftypes.String,
│ "billing_account_name":tftypes.String, "name":tftypes.String,
...
```